### PR TITLE
Update campaignion_context.context.inc

### DIFF
--- a/modules/campaignion_context/campaignion_context.context.inc
+++ b/modules/campaignion_context/campaignion_context.context.inc
@@ -257,6 +257,7 @@ function campaignion_context_context_default_contexts() {
     'path' => array(
       'values' => array(
         '~node/*/share' => '~node/*/share',
+        '~node/*/webform-continue/*' => '~node/*/webform-continue/*',
       ),
     ),
   );


### PR DESCRIPTION
Fixes the display of two webforms (one in content and one as block) if you cancel your payment on an external payment provider and get redirected back to campaignion.